### PR TITLE
Add centralized path configuration for outputs

### DIFF
--- a/evaluate_generalization.py
+++ b/evaluate_generalization.py
@@ -1,14 +1,19 @@
+import argparse
+from pathlib import Path
+
 import torch
-from torchvision import datasets, transforms
 from torch.utils.data import DataLoader
-import os
+from torchvision import datasets, transforms
 import matplotlib.pyplot as plt
+
 from diffusion_model import SimpleWeightSpaceDiffusion, flatten_state_dict, unflatten_to_state_dict, get_target_model_flat_dim
 from target_cnn import TargetCNN
+from utils.paths import ensure_parent_directory, resolve_path
 
 # --- Configuration ---
-DIFFUSION_MODEL_PATH = "diffusion_optimizer.pth"
-TRAJECTORY_DIR = "trajectory_weights_cnn"
+DEFAULT_DIFFUSION_MODEL_PATH = "diffusion_optimizer.pth"
+DEFAULT_TRAJECTORY_DIR = "trajectory_weights_cnn"
+DEFAULT_PLOT_PATH = "diffusion_evaluation_plot.png"
 NUM_GENERATION_STEPS = 6
 BATCH_SIZE = 512
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -35,14 +40,20 @@ def evaluate_model(model, test_loader, device):
     return accuracy, avg_loss
 
 # --- Main Execution ---
-def run_evaluation():
+def run_evaluation(
+    diffusion_model_path: Path,
+    trajectory_dir: Path,
+    plot_path: Path,
+    num_generation_steps: int,
+    batch_size: int
+) -> None:
     print("Starting evaluation of diffusion-generated trajectory...")
     print(f"Using device: {DEVICE}")
 
     # --- Data Loading ---
     transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))])
     test_dataset = datasets.MNIST(root='./data', train=False, download=True, transform=transform)
-    test_loader = DataLoader(test_dataset, batch_size=BATCH_SIZE, shuffle=False)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
 
     # --- Model Initialization ---
     # Create a reference TargetCNN to get dimensions and structure
@@ -57,12 +68,12 @@ def run_evaluation():
         time_emb_dim=128,
         hidden_dim=1024
     ).to(DEVICE)
-    diffusion_model.load_state_dict(torch.load(DIFFUSION_MODEL_PATH, map_location=DEVICE))
+    diffusion_model.load_state_dict(torch.load(diffusion_model_path, map_location=DEVICE))
     diffusion_model.eval()
-    print(f"Diffusion model loaded from {DIFFUSION_MODEL_PATH}")
+    print(f"Diffusion model loaded from {diffusion_model_path}")
 
     # --- Trajectory Generation ---
-    print(f"Will generate a trajectory of {NUM_GENERATION_STEPS} steps.")
+    print(f"Will generate a trajectory of {num_generation_steps} steps.")
     generated_weights_sequence = []
 
     # 1. Create a NEW TargetCNN with random weights
@@ -71,15 +82,15 @@ def run_evaluation():
     generated_weights_sequence.append(current_weights_flat)
 
     # 2. Iteratively apply the diffusion model
-    print(f"Generating trajectory with diffusion model for {NUM_GENERATION_STEPS} steps...")
+    print(f"Generating trajectory with diffusion model for {num_generation_steps} steps...")
     with torch.no_grad():
-        for t in range(NUM_GENERATION_STEPS):
+        for t in range(num_generation_steps):
             timestep = torch.tensor([[t]], dtype=torch.float32).to(DEVICE)
             # Predict the next set of weights
             next_weights_flat = diffusion_model(current_weights_flat.unsqueeze(0), timestep).squeeze(0)
             generated_weights_sequence.append(next_weights_flat)
             current_weights_flat = next_weights_flat
-            print(f"Generated step {t+1}/{NUM_GENERATION_STEPS}")
+            print(f"Generated step {t+1}/{num_generation_steps}")
 
     # --- Performance Evaluation ---
     print("\nEvaluating performance along the generated trajectory...")
@@ -94,15 +105,15 @@ def run_evaluation():
         if i == 0:
             print(f"Step {i} (Initial Random Weights): Accuracy = {accuracy:.2f}%, Avg Loss = {avg_loss:.4f}")
         else:
-            print(f"Generated Step {i}/{NUM_GENERATION_STEPS}: Accuracy = {accuracy:.2f}%, Avg Loss = {avg_loss:.4f}")
+            print(f"Generated Step {i}/{num_generation_steps}: Accuracy = {accuracy:.2f}%, Avg Loss = {avg_loss:.4f}")
 
     # --- Compare with Original Trajectory ---
     print("\nEvaluating performance along the original CNN training trajectory...")
     orig_accuracies, orig_losses = [], []
     original_cnn = TargetCNN().to(DEVICE)
-    for epoch in range(NUM_GENERATION_STEPS + 1):
-        weight_file = os.path.join(TRAJECTORY_DIR, f"weights_epoch_{epoch}.pth")
-        if os.path.exists(weight_file):
+    for epoch in range(num_generation_steps + 1):
+        weight_file = trajectory_dir / f"weights_epoch_{epoch}.pth"
+        if weight_file.exists():
             original_cnn.load_state_dict(torch.load(weight_file, map_location=DEVICE))
             accuracy, avg_loss = evaluate_model(original_cnn, test_loader, DEVICE)
             orig_accuracies.append(accuracy)
@@ -136,14 +147,36 @@ def run_evaluation():
     plt.ylabel("Average Loss")
     plt.legend()
     plt.grid(True)
-    
+
     plt.tight_layout(rect=[0, 0, 1, 0.96])
-    plot_path = "diffusion_evaluation_plot.png"
     plt.savefig(plot_path)
     print(f"Plot saved to {plot_path}")
-    
+
     print("\nEvaluation finished.")
 
 
 if __name__ == "__main__":
-    run_evaluation()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--diffusion-model-path", type=str, default=DEFAULT_DIFFUSION_MODEL_PATH)
+    parser.add_argument("--trajectory-dir", type=str, default=DEFAULT_TRAJECTORY_DIR)
+    parser.add_argument("--plot-path", type=str, default=DEFAULT_PLOT_PATH)
+    parser.add_argument("--output-base-dir", type=str, default=None)
+    parser.add_argument("--num-steps", type=int, default=NUM_GENERATION_STEPS)
+    parser.add_argument("--batch-size", type=int, default=BATCH_SIZE)
+    args = parser.parse_args()
+    base_dir = args.output_base_dir
+    diffusion_model_path = resolve_path(args.diffusion_model_path, base_dir=base_dir)
+    trajectory_dir = resolve_path(args.trajectory_dir, base_dir=base_dir)
+    plot_path = ensure_parent_directory(args.plot_path, base_dir=base_dir)
+    if not diffusion_model_path.exists():
+        print(f"Error: Diffusion model not found at '{diffusion_model_path}'.")
+    elif not trajectory_dir.is_dir() or not any(trajectory_dir.iterdir()):
+        print(f"Error: Trajectory directory '{trajectory_dir}' is empty or does not exist.")
+    else:
+        run_evaluation(
+            diffusion_model_path=diffusion_model_path,
+            trajectory_dir=trajectory_dir,
+            plot_path=plot_path,
+            num_generation_steps=args.num_steps,
+            batch_size=args.batch_size
+        )

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,0 +1,37 @@
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+PathLike = Union[str, Path]
+OUTPUT_BASE_ENV = "EXPERIMENT_OUTPUT_BASE_DIR"
+
+def _coerce_path(value: PathLike) -> Path:
+    return Path(value).expanduser()
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+def get_base_dir(explicit_base: Optional[PathLike] = None) -> Path:
+    if explicit_base is not None:
+        return _coerce_path(explicit_base).resolve()
+    env_dir = os.getenv(OUTPUT_BASE_ENV)
+    if env_dir:
+        return _coerce_path(env_dir).resolve()
+    return project_root()
+
+def resolve_path(path: PathLike, base_dir: Optional[PathLike] = None) -> Path:
+    candidate = _coerce_path(path)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    base_path = get_base_dir(base_dir)
+    return (base_path / candidate).resolve()
+
+def ensure_directory(path: PathLike, base_dir: Optional[PathLike] = None) -> Path:
+    directory = resolve_path(path, base_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+def ensure_parent_directory(path: PathLike, base_dir: Optional[PathLike] = None) -> Path:
+    file_path = resolve_path(path, base_dir)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    return file_path


### PR DESCRIPTION
## Summary
- add a reusable path utility that resolves output directories with optional environment or base directory overrides
- update training and evaluation scripts to accept CLI arguments for trajectory, checkpoint, and plot locations using the shared resolver
- ensure saved artifacts are created via pathlib so paths remain portable across platforms

## Testing
- python -m compileall train_target_model.py train_diffusion.py evaluate_diffusion.py evaluate_generalization.py utils/paths.py

------
https://chatgpt.com/codex/tasks/task_e_68c9027cc87483258741c9fd19b50e46